### PR TITLE
npm fetch: ensure npm package is downloaded to the expected directory ev...

### DIFF
--- a/lib/npm.py
+++ b/lib/npm.py
@@ -72,6 +72,8 @@ class NPM(FetchMethod):
         if not os.path.exists(ud.installdir):
             bb.utils.mkdirhier(ud.installdir)
         os.chdir(ud.installdir)
+        with open("package.json", 'w') as f:
+            f.write("{}\n")
         logger.info("npm install " + ud.url)
         logger.debug(2, "executing " + fetchcmd)
         bb.fetch2.check_network_access(d, fetchcmd)


### PR DESCRIPTION
...en if npm would detect a different package root above it

Without this, `npm` might download the package to a parent directory that already contained "node_modules" (for example: $HOME/node_modules). npm.py would then fail durring unpack as nothing would be placed in it's download directory.
